### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/memcached.yaml
+++ b/memcached.yaml
@@ -23,7 +23,7 @@ base:
     private: true
   containers:
     memcached:
-      image: bitnami/memcached
+      image: bitnamilegacy/memcached
       image-tag: latest
 
 memcached:


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.